### PR TITLE
Changed event constructor for node.js 19+

### DIFF
--- a/test/sendLogs_spec.js
+++ b/test/sendLogs_spec.js
@@ -97,7 +97,7 @@ describe('sendLogs', () => {
         };
         sendOnClose([], {on: true, url: 'test'})
         sendOnClose([{foo: 'bar'}], {on: true, url: 'test'});
-        global.window.dispatchEvent(new CustomEvent('pagehide'))
+        global.window.dispatchEvent(new window.CustomEvent('pagehide'))
         sinon.assert.calledOnce(sendBeaconSpy)
     });
 
@@ -107,7 +107,7 @@ describe('sendLogs', () => {
             sendBeacon: sendBeaconSpy
         };
         sendOnClose([{foo: 'bar'}], {on: false, url: 'test'});
-        global.window.dispatchEvent(new CustomEvent('pagehide'))
+        global.window.dispatchEvent(new window.CustomEvent('pagehide'))
         sinon.assert.notCalled(sendBeaconSpy)
     });
 });


### PR DESCRIPTION
https://github.com/apache/flagon-useralejs/issues/373

I'm not entirely sure what changed from 18->19, but here is an explanation of the bug and why this change fixes it.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms