### PR TITLE
Feature: Adding tabId to log

### DIFF
--- a/build/UserALEWebExtension/background.js
+++ b/build/UserALEWebExtension/background.js
@@ -415,7 +415,7 @@ function createVersionParts(count) {
  * limitations under the License.
  */
 
-var browser$1 = detect();
+var browserInfo = detect();
 var logs$1;
 var config$1;
 
@@ -706,8 +706,8 @@ function selectorizePath(path) {
 }
 function detectBrowser() {
   return {
-    'browser': browser$1 ? browser$1.name : '',
-    'version': browser$1 ? browser$1.version : ''
+    'browser': browserInfo ? browserInfo.name : '',
+    'version': browserInfo ? browserInfo.version : ''
   };
 }
 
@@ -1142,7 +1142,7 @@ function dispatchTabMessage(message) {
     });
   });
 }
-browser.runtime.onMessage.addListener(function (message) {
+browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   switch (message.type) {
     case CONFIG_CHANGE:
       options(message.payload);
@@ -1151,7 +1151,11 @@ browser.runtime.onMessage.addListener(function (message) {
 
     // Handles logs rerouted from content and option scripts 
     case ADD_LOG:
-      log(message.payload);
+      var log$1 = message.payload;
+      if ("tab" in sender && "id" in sender.tab) {
+        log$1["tabId"] = sender.tab.id;
+      }
+      log(log$1);
       break;
     default:
       console.log('got unknown message type ', message);

--- a/build/UserALEWebExtension/content.js
+++ b/build/UserALEWebExtension/content.js
@@ -405,7 +405,7 @@ function createVersionParts(count) {
  * limitations under the License.
  */
 
-var browser$1 = detect();
+var browserInfo = detect();
 var logs$1;
 var config$1;
 
@@ -720,8 +720,8 @@ function selectorizePath(path) {
 }
 function detectBrowser() {
   return {
-    'browser': browser$1 ? browser$1.name : '',
-    'version': browser$1 ? browser$1.version : ''
+    'browser': browserInfo ? browserInfo.name : '',
+    'version': browserInfo ? browserInfo.version : ''
   };
 }
 
@@ -1100,7 +1100,6 @@ function options(newConfig) {
 // browser is defined in firefox, but chrome uses the 'chrome' global.
 var browser = browser || chrome;
 function rerouteLog(log) {
-  console.log(log);
   browser.runtime.sendMessage({
     type: ADD_LOG,
     payload: log

--- a/build/UserALEWebExtension/options.js
+++ b/build/UserALEWebExtension/options.js
@@ -405,7 +405,7 @@ function createVersionParts(count) {
  * limitations under the License.
  */
 
-var browser$1 = detect();
+var browserInfo = detect();
 var logs$1;
 var config$1;
 
@@ -720,8 +720,8 @@ function selectorizePath(path) {
 }
 function detectBrowser() {
   return {
-    'browser': browser$1 ? browser$1.name : '',
-    'version': browser$1 ? browser$1.version : ''
+    'browser': browserInfo ? browserInfo.name : '',
+    'version': browserInfo ? browserInfo.version : ''
   };
 }
 
@@ -1100,7 +1100,6 @@ function options(newConfig) {
 // browser is defined in firefox, but chrome uses the 'chrome' global.
 var browser = browser || chrome;
 function rerouteLog(log) {
-  console.log(log);
   browser.runtime.sendMessage({
     type: ADD_LOG,
     payload: log

--- a/build/userale-2.4.0.js
+++ b/build/userale-2.4.0.js
@@ -418,7 +418,7 @@
    * limitations under the License.
    */
 
-  var browser = detect();
+  var browserInfo = detect();
   var logs$1;
   var config$1;
 
@@ -745,8 +745,8 @@
   }
   function detectBrowser() {
     return {
-      'browser': browser ? browser.name : '',
-      'version': browser ? browser.version : ''
+      'browser': browserInfo ? browserInfo.name : '',
+      'version': browserInfo ? browserInfo.version : ''
     };
   }
 

--- a/src/UserALEWebExtension/background.js
+++ b/src/UserALEWebExtension/background.js
@@ -43,7 +43,7 @@ function dispatchTabMessage(message) {
   });
 }
 
-browser.runtime.onMessage.addListener(function (message) {
+browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   switch (message.type) {
     case MessageTypes.CONFIG_CHANGE:
       userale.options(message.payload)
@@ -52,7 +52,11 @@ browser.runtime.onMessage.addListener(function (message) {
 
     // Handles logs rerouted from content and option scripts 
     case MessageTypes.ADD_LOG:
-      userale.log(message.payload);
+      let log = message.payload;
+      if("tab" in sender && "id" in sender.tab) {
+        log["tabId"] = sender.tab.id;
+      }
+      userale.log(log);
       break;
 
     default:
@@ -75,7 +79,6 @@ function packageDetailedTabLog(tab, data, type) {
 // Attach Handlers for tab events
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
 browser.tabs.onActivated.addListener((activeInfo) => {
-  browser.storage.local.set({ "tabId": activeInfo.tabId });
   packageTabLog(activeInfo.tabId, activeInfo, "tabs.onActivated");
 });
 

--- a/src/UserALEWebExtension/background.js
+++ b/src/UserALEWebExtension/background.js
@@ -75,6 +75,9 @@ function packageDetailedTabLog(tab, data, type) {
 // Attach Handlers for tab events
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
 browser.tabs.onActivated.addListener((activeInfo) => {
+  browser.storage.local.set({ "tabId": e.tabId }, function() {
+    console.log("The tabID has been set in storage.local");
+  });
   packageTabLog(activeInfo.tabId, activeInfo, "tabs.onActivated");
 });
 

--- a/src/UserALEWebExtension/background.js
+++ b/src/UserALEWebExtension/background.js
@@ -75,9 +75,7 @@ function packageDetailedTabLog(tab, data, type) {
 // Attach Handlers for tab events
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
 browser.tabs.onActivated.addListener((activeInfo) => {
-  browser.storage.local.set({ "tabId": e.tabId }, function() {
-    console.log("The tabID has been set in storage.local");
-  });
+  browser.storage.local.set({ "tabId": activeInfo.tabId });
   packageTabLog(activeInfo.tabId, activeInfo, "tabs.onActivated");
 });
 

--- a/src/packageLogs.js
+++ b/src/packageLogs.js
@@ -33,7 +33,6 @@ export let filterHandler = null;
 export let mapHandler = null;
 export let cbHandlers = {};
 
-
 /**
  * Assigns a handler to filter logs out of the queue.
  * @deprecated Use addCallbacks and removeCallbacks instead
@@ -106,28 +105,12 @@ export function initPackager(newLogs, newConfig) {
 }
 
 /**
- * Get the tabID from local storage
- */
-export function getTabId() {
-  const api = (typeof browser !== 'undefined') ? browser : chrome;
-  return new Promise((resolve, reject) => {
-    api.storage.local.get("tabId", function(result) {
-      if (result.tabId !== undefined) {
-        resolve(result.tabId);
-      } else {
-        reject('tabId not found');
-      }
-    });
-  });
-}
-
-/**
  * Transforms the provided HTML event into a log and appends it to the log queue.
  * @param  {Object} e         The event to be logged.
  * @param  {Function} detailFcn The function to extract additional log parameters from the event.
  * @return {boolean}           Whether the event was logged.
  */
-export async function packageLog(e, detailFcn) {
+export function packageLog(e, detailFcn) {
   if (!config.on) {
     return false;
   }
@@ -140,8 +123,6 @@ export async function packageLog(e, detailFcn) {
   const timeFields = extractTimeFields(
     (e.timeStamp && e.timeStamp > 0) ? config.time(e.timeStamp) : Date.now()
   );
-
-  const tabId = await getTabId();
 
   let log = {
     'target' : getSelector(e.target),
@@ -162,7 +143,6 @@ export async function packageLog(e, detailFcn) {
     'toolVersion' : config.version,
     'toolName' : config.toolName,
     'useraleVersion': config.useraleVersion,
-    'tabId': tabId,
     'sessionID': config.sessionID,
   };
 
@@ -194,7 +174,7 @@ export async function packageLog(e, detailFcn) {
  * @param  {boolean} userAction     Indicates user behavior (true) or system behavior (false)
  * @return {boolean}           Whether the event was logged.
  */
-export async function packageCustomLog(customLog, detailFcn, userAction) {
+export function packageCustomLog(customLog, detailFcn, userAction) {
     if (!config.on) {
         return false;
     }
@@ -203,8 +183,6 @@ export async function packageCustomLog(customLog, detailFcn, userAction) {
     if (detailFcn) {
         details = detailFcn();
     }
-
-    const tabId = await getTabId();
 
     const metaData = {
         'pageUrl': window.location.href,
@@ -220,7 +198,6 @@ export async function packageCustomLog(customLog, detailFcn, userAction) {
         'toolVersion' : config.version,
         'toolName' : config.toolName,
         'useraleVersion': config.useraleVersion,
-        'tabId': tabId,
         'sessionID': config.sessionID
     };
 
@@ -266,7 +243,7 @@ export function extractTimeFields(timeStamp) {
  * @param {Object} e
  * @return boolean
  */
-export async function packageIntervalLog(e) {
+export function packageIntervalLog(e) {
     const target = getSelector(e.target);
     const path = buildPath(e);
     const type = e.type;
@@ -280,8 +257,6 @@ export async function packageIntervalLog(e) {
         intervalTimer = timestamp;
         intervalCounter = 0;
     }
-
-    const tabId = await getTabId();
 
     if (intervalID !== target || intervalType !== type) {
         // When to create log? On transition end
@@ -307,7 +282,6 @@ export async function packageIntervalLog(e) {
             'toolVersion': config.version,
             'toolName': config.toolName,
             'useraleVersion': config.useraleVersion,
-            'tabId': tabId,
             'sessionID': config.sessionID
         };
 

--- a/src/packageLogs.js
+++ b/src/packageLogs.js
@@ -16,7 +16,7 @@
  */
 
 import { detect } from 'detect-browser';
-const browser = detect();
+const browserInfo = detect();
 
 export let logs;
 let config;
@@ -108,9 +108,10 @@ export function initPackager(newLogs, newConfig) {
 /**
  * Get the tabID from local storage
  */
-function getTabId() {
+export function getTabId() {
+  const api = (typeof browser !== 'undefined') ? browser : chrome;
   return new Promise((resolve, reject) => {
-    chrome.storage.local.get("tabId", function(result) {
+    api.storage.local.get("tabId", function(result) {
       if (result.tabId !== undefined) {
         resolve(result.tabId);
       } else {
@@ -416,7 +417,7 @@ export function selectorizePath(path) {
 
 export function detectBrowser() {
     return {
-        'browser': browser ? browser.name : '',
-        'version': browser ? browser.version : ''
+        'browser': browserInfo ? browserInfo.name : '',
+        'version': browserInfo ? browserInfo.version : ''
     };
 }


### PR DESCRIPTION
Logs that are not associated with tab events do not have information about which tab (tab Id) that the activities occurred in. We add tab ID information to all logs to facilitate future capability to parse logs based on the tab. 